### PR TITLE
Fix "LoginRequired" detection on MBASIC

### DIFF
--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -955,6 +955,7 @@ class FacebookScraper:
                     title.text == "Log in to Facebook | Facebook"
                     or response.url.startswith(utils.urljoin(FB_MOBILE_BASE_URL, "login"))
                     or response.url.startswith(utils.urljoin(FB_W3_BASE_URL, "login"))
+                    or response.url.startswith(utils.urljoin(FB_MBASIC_BASE_URL, "login"))
                 ):
                     raise exceptions.LoginRequired(
                         "A login (cookies) is required to see this page"


### PR DESCRIPTION
Fix: "LoginRequired" does not raised on mbasic.facebook.com

![image](https://github.com/moda20/facebook-scraper/assets/12305552/02039a1d-b6e0-478d-8b8b-6371c43a2a8d)
