### PR TITLE
The options of obtaining "reactions" and "reactors" are separated

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,10 @@ We’re headed to PAX East 3/28-3/31 with new games
   - A [CookieJar](https://docs.python.org/3.9/library/http.cookiejar.html#http.cookiejar.CookieJar)
   - A dictionary that can be converted to a CookieJar with [cookiejar_from_dict](https://2.python-requests.org/en/master/api/#requests.cookies.cookiejar_from_dict)
   - The string `"from_browser"` to try extract Facebook cookies from your browser
-* **options**: Dictionary of options. Set `options={"comments": True}` to extract comments, set `options={"reactors": True}` to extract the people reacting to the post.
+* **options**: Dictionary of options. 
+  * Set `options={"comments": True}` to extract comments.
+  * Set `options={"reactors": True}` to extract the people reacting to the post. 
+  * Set `options={"reactions": True}` to extract the reactions of the post. Similar to `reactors` but only extracts reactions and not the people who reacted. Makes only one request per post 
   * Both `comments` and `reactors` can also be set to a number to set a limit for the amount of comments/reactors to retrieve.
   * Set `options={"progress": True}` to get a `tqdm` progress bar while extracting comments and replies.
   * Set `options={"allow_extra_requests": False}` to disable making extra requests when extracting post data (required for some things like full text and image links).

--- a/facebook_scraper/extractors.py
+++ b/facebook_scraper/extractors.py
@@ -947,8 +947,9 @@ class PostExtractor:
         w3_fb_url = url and utils.urlparse(url)._replace(netloc='www.facebook.com').geturl()
 
         reactors_opt = self.options.get("reactors")
+        reactions_opt = self.options.get("reactions")
         reactors = []
-        if reactors_opt:
+        if reactors_opt or reactions_opt:
             reaction_url = f'https://m.facebook.com/ufi/reaction/profile/browser/?ft_ent_identifier={post_id}'
             logger.debug(f"Fetching {reaction_url}")
             response = self.request(reaction_url)
@@ -972,7 +973,8 @@ class PostExtractor:
                         reactions[name] = v
                 if not reaction_count:
                     reaction_count = sum(reactions.values())
-            reactors = self.extract_reactors(response, reaction_lookup)
+            if reactors_opt:
+                reactors = self.extract_reactors(response, reaction_lookup)
 
         if reactions:
             return {

--- a/facebook_scraper/facebook_scraper.py
+++ b/facebook_scraper/facebook_scraper.py
@@ -98,7 +98,7 @@ class FacebookScraper:
         )
         logger.debug(f"Fetching {reaction_url}")
         response = self.get(reaction_url)
-        extractor = PostExtractor(response.html, kwargs, self.get, full_post_html=response.html)
+        extractor = PostExtractor(response.html, kwargs, self.get, full_post_html=response.html, scraper=self)
         return extractor.extract_reactors(response)
 
     def get_photos(self, account: str, **kwargs) -> Iterator[Post]:


### PR DESCRIPTION
Currently, in order to obtain the reactions it is necessary to pass the "reactors" option, the problem with this is that to search for the reactors you have to make additional requests, whereas for the reactions you only have to make an additional request.
In the event that we do not want to know the individual reactors but the reactions, it is important to separate the options.